### PR TITLE
Properly handle the case when std::io::Write::write doesn't write all of the buffer.

### DIFF
--- a/webbundle/src/encoder.rs
+++ b/webbundle/src/encoder.rs
@@ -32,8 +32,13 @@ impl<W> CountWrite<W> {
 
 impl<W: Write> Write for CountWrite<W> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.count += buf.len();
-        self.inner.write(buf)
+        match self.inner.write(buf) {
+            Ok(n) => {
+                self.count += n;
+                Ok(n)
+            },
+            Err(e) => Err(e),
+        }
     }
     fn flush(&mut self) -> std::io::Result<()> {
         self.inner.flush()

--- a/webbundle/src/encoder.rs
+++ b/webbundle/src/encoder.rs
@@ -36,7 +36,7 @@ impl<W: Write> Write for CountWrite<W> {
             Ok(n) => {
                 self.count += n;
                 Ok(n)
-            },
+            }
             Err(e) => Err(e),
         }
     }


### PR DESCRIPTION
`std::io::Write::write` doesn't necessarily write the entire buffer even on success, thus there's a little chance that the invariant, `cout == <# of bytes written to inner>`, would break in `CountWrite`.

This PR fixes it by explicitly handling the returned value by `write`. We may also fix this problem by using `std::io::Write::write_all` instead, but as `CountWrite` is a very simple, thin wrapper of a `std::io::Write`, I believe this is the preferred way (note that those incomplete writes will be handled in the end because the crate cbor_event makes use of `write_all` appropriately https://github.com/primetype/cbor_event/blob/874f578d4e2809d6397237b7a155e9a7787c9f8a/src/se.rs#L294).